### PR TITLE
Off by 1 error

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,7 +167,7 @@ function initChart() {
 
             while (currentLap <= maxLap) {
                 // Duration is based on original schedule (odd = 11, even = 13)
-                const sectionLaps = sectionNumber % 2 === 1 ? 11 : 13;
+                const sectionLaps = sectionNumber === 1 ? 10 : (sectionNumber % 2 === 1 ? 11 : 13);
                 const sectionEnd = Math.min(currentLap + sectionLaps - 1, maxLap);
 
                 // Appearance is based on isTrailSection (handles rain exception)
@@ -199,7 +199,7 @@ function initChart() {
 
             while (currentLap <= maxLap) {
                 // Duration is based on original schedule (odd = 11, even = 13)
-                const sectionLaps = sectionNumber % 2 === 1 ? 11 : 13;
+                const sectionLaps = sectionNumber === 1 ? 10 : (sectionNumber % 2 === 1 ? 11 : 13);
                 const sectionEnd = Math.min(currentLap + sectionLaps - 1, maxLap);
                 const centerLap = currentLap + (sectionLaps - 1) / 2;
 


### PR DESCRIPTION
This person ran 50 loops but it only shows one yellow bar at the end when it should be 2.

<img width="1444" height="576" alt="Screenshot 2025-10-26 at 11 13 40" src="https://github.com/user-attachments/assets/af7f73fc-a376-4a1d-9c99-4204bac56fea" />

There is an off by 1 error because at the start, we only show the end of the first lap and not the actual first lap (graph starts at 1 not 0, so there is no bar for 0->1, just 1-> 2). This PR fixes that, so 48->49 etc. is now yellow.

<img width="1447" height="541" alt="Screenshot 2025-10-26 at 11 15 26" src="https://github.com/user-attachments/assets/dee7185c-b2a5-4522-8145-6316ead2643f" />
